### PR TITLE
Fix global toctree generation with JSON builder.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,5 +10,12 @@ author-email = "carlton.gibson@noumenal.es"
 description-file = "README.md"
 home-page = "https://noumenal.es/django-sphinx-view/"
 
+[tool.flit.metadata.requires-extra]
+test = [
+    "Django>=4.2",
+    "pytest>=8",
+    "Sphinx>=6",
+]
+
 [tool.flit.metadata.urls]
 GitHub = "https://github.com/carltongibson/django-sphinx-view"

--- a/sphinx_view/builders.py
+++ b/sphinx_view/builders.py
@@ -9,5 +9,9 @@ class SphinxViewBuilder(JSONHTMLBuilder):
     def get_doc_context(self, docname, body, metatags):
         doc = super().get_doc_context(docname, body, metatags)
         self_toctree = TocTree(self.env).get_toctree_for(docname, self, True)
-        doc['toctree'] = lambda **kwargs: self.render_partial(self_toctree)['fragment']
+        doc['toctree'] = (
+            self.render_partial(self_toctree)['fragment']
+            if self_toctree
+            else ''
+        )
         return doc

--- a/tests/test_json_builder_toctree.py
+++ b/tests/test_json_builder_toctree.py
@@ -1,0 +1,68 @@
+import json
+from pathlib import Path
+
+from sphinx.cmd.build import main as sphinx_build
+
+
+def _write(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+
+
+def _build_json(src: Path, out: Path, doctrees: Path) -> int:
+    return sphinx_build(
+        [
+            "-E",
+            "-a",
+            "-b",
+            "json",
+            str(src),
+            str(out),
+            "-d",
+            str(doctrees),
+        ]
+    )
+
+
+def test_toctree_serialized_as_string_in_fjson(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    out = tmp_path / "_build" / "json"
+    doctrees = tmp_path / "_build" / "doctrees"
+    src.mkdir(parents=True)
+
+    _write(
+        src / "conf.py",
+        "extensions = ['sphinx_view']\nproject = 'test-project'\nroot_doc = 'index'\n",
+    )
+    _write(
+        src / "index.rst",
+        "Home\n====\n\n.. toctree::\n   :maxdepth: 1\n\n   changelog\n",
+    )
+    _write(src / "changelog.rst", "Changelog\n=========\n\nEntry.\n")
+
+    assert _build_json(src, out, doctrees) == 0
+
+    data = json.loads((out / "changelog.fjson").read_text(encoding="utf-8"))
+    assert "toc" in data
+    assert "toctree" in data
+    assert isinstance(data["toctree"], str)
+    assert data["toctree"] != ""
+
+
+def test_toctree_key_present_even_without_toctree_directive(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    out = tmp_path / "_build" / "json"
+    doctrees = tmp_path / "_build" / "doctrees"
+    src.mkdir(parents=True)
+
+    _write(
+        src / "conf.py",
+        "extensions = ['sphinx_view']\nproject = 'test-project'\nroot_doc = 'index'\n",
+    )
+    _write(src / "index.rst", "Home\n====\n\nNo toctree here.\n")
+
+    assert _build_json(src, out, doctrees) == 0
+
+    data = json.loads((out / "index.fjson").read_text(encoding="utf-8"))
+    assert "toctree" in data
+    assert isinstance(data["toctree"], str)
+    assert data["toctree"] == ""


### PR DESCRIPTION
`JSONHTMLBuilder.handle_page()` removes function-valued context keys before serializing:

```python
for key in list(ctx):
    if isinstance(ctx[key], types.FunctionType):
        del ctx[key]
```

Ensure toctree is serialised in SphinxViewBuilder.

Add regression test to ensure toctree is included in final doc context.

Reverts #26, but reopens #25 for compatibility with HTML builder when using Furo theme.